### PR TITLE
👔 Checking if the order can be cancelled before trying - PRD-3141

### DIFF
--- a/src/Command/Sales/Order/Processor/CanceledCommand.php
+++ b/src/Command/Sales/Order/Processor/CanceledCommand.php
@@ -77,6 +77,17 @@ class CanceledCommand extends AbstractProcessorCommand
             return 0;
         }
 
+        // Check if order can be canceled
+        if(!$order->canCancel()){
+            $this->logger->error(
+                sprintf(
+                    "Order with ID %s can't be canceled",
+                    $order->getId()
+                )
+            );
+            return 0;
+        }
+
         $this->cancelOrder($order);
 
         return 0;

--- a/src/Command/Sales/Order/Processor/CanceledCommand.php
+++ b/src/Command/Sales/Order/Processor/CanceledCommand.php
@@ -77,17 +77,6 @@ class CanceledCommand extends AbstractProcessorCommand
             return 0;
         }
 
-        // Check if order can be canceled
-        if(!$order->canCancel()){
-            $this->logger->error(
-                sprintf(
-                    "Order with ID %s can't be canceled",
-                    $order->getId()
-                )
-            );
-            return 0;
-        }
-
         $this->cancelOrder($order);
 
         return 0;
@@ -96,7 +85,8 @@ class CanceledCommand extends AbstractProcessorCommand
     private function cancelOrder($order): void
     {
         try {
-            if ($order->canCreditmemo() && $order->hasInvoice()) {
+            $invoices = $order->getInvoiceCollection();
+            if ($order->canCreditmemo() && $invoices->getSize() > 0) {
                 $itemIdsToRefund = [];
                 foreach ($order->getAllItems() as $orderItem) {
                     $creditMemoItem = $this->itemCreationFactory->create();
@@ -118,19 +108,27 @@ class CanceledCommand extends AbstractProcessorCommand
                 }
             }
 
-            $order->cancel();
-            
-            $order->save();
-            $this->addOrderHistory(
-                __('Order canceled!')->__toString(),
-                (int) $order->getId()
-            );
-            $this->logger->info(
-                sprintf(
-                    "Order with ID %s canceled",
-                    (string) $order->getId()
-                )
-            );
+            if ($order->canCancel()) {
+                $order->cancel();
+                $order->save();
+                $this->addOrderHistory(
+                    __('Order canceled!')->__toString(),
+                    (int) $order->getId()
+                );
+                $this->logger->info(
+                    sprintf(
+                        "Order with ID %s canceled",
+                        (string) $order->getId()
+                    )
+                );
+            } else {
+                $this->logger->info(
+                    sprintf(
+                        "Order with ID %s cannot be canceled but credit memo was created",
+                        (string) $order->getId()
+                    )
+                );
+            }
         } catch (Throwable $e) {
             $this->logger->error(
                 sprintf(


### PR DESCRIPTION
This pr applies a new layer of logic so that it is possible to first check whether the order can be cancelled or not, so that the order comment history is not dirty.

The ticket can be checket  with tag `PRD-3141`