### PR TITLE
🐛 Fixed menu ACL permissions - Gubee_Integration::Message and Gubee_I…

### DIFF
--- a/src/Controller/Adminhtml/Message/Detail/Index.php
+++ b/src/Controller/Adminhtml/Message/Detail/Index.php
@@ -11,6 +11,8 @@ use Magento\Framework\Controller\Result\JsonFactory;
 
 class Index extends Action
 {
+    const ADMIN_RESOURCE = 'Gubee_Integration::Message';
+
     protected JsonFactory $resultPageFactory;
     protected CollectionFactory $detailCollectionFactory;
     /**

--- a/src/Controller/Adminhtml/Message/Execute.php
+++ b/src/Controller/Adminhtml/Message/Execute.php
@@ -14,6 +14,8 @@ use function __;
 
 class Execute extends Action
 {
+    const ADMIN_RESOURCE = 'Gubee_Integration::Message';
+
     protected MessageRepositoryInterface $messageRepository;
     protected Management $management;
 

--- a/src/Controller/Adminhtml/Message/Index.php
+++ b/src/Controller/Adminhtml/Message/Index.php
@@ -13,6 +13,8 @@ use function __;
 
 class Index extends Action
 {
+    const ADMIN_RESOURCE = 'Gubee_Integration::Message';
+
     protected PageFactory $resultPageFactory;
 
     /**

--- a/src/Controller/Adminhtml/Message/Order/Unsuccessful/Index.php
+++ b/src/Controller/Adminhtml/Message/Order/Unsuccessful/Index.php
@@ -13,6 +13,8 @@ use function __;
 
 class Index extends Action
 {
+    const ADMIN_RESOURCE = 'Gubee_Integration::UnsuccessfulOrders';
+
     protected PageFactory $resultPageFactory;
 
     /**

--- a/src/Controller/Adminhtml/Message/Queue.php
+++ b/src/Controller/Adminhtml/Message/Queue.php
@@ -15,6 +15,8 @@ use function __;
 
 class Queue extends Action
 {
+    const ADMIN_RESOURCE = 'Gubee_Integration::Message';
+
     protected MessageRepositoryInterface $messageRepository;
     protected Management $management;
 

--- a/src/etc/acl.xml
+++ b/src/etc/acl.xml
@@ -4,7 +4,8 @@
         <resources>
             <resource id="Magento_Backend::admin">
                 <resource id="Gubee_Integration::gubee_integration" title="gubee integration" sortOrder="10">
-                    <resource id="Gubee_Integration::index_index" title="index index" sortOrder="10"/>
+                    <resource id="Gubee_Integration::Message" title="Gubee Messages" sortOrder="20"/>
+                    <resource id="Gubee_Integration::UnsuccessfulOrders" title="Unsuccessful Orders Integration" sortOrder="30"/>
                 </resource>
             </resource>
         </resources>

--- a/src/view/adminhtml/ui_component/gubee_message_order_unsuccessful_index_listing.xml
+++ b/src/view/adminhtml/ui_component/gubee_message_order_unsuccessful_index_listing.xml
@@ -22,7 +22,7 @@
                 <param name="command">Gubee\Integration\Command\Sales\Order\Processor\CreatedCommand</param>
             </filterUrlParams>
         </settings>
-        <aclResource>Gubee_Integration::Message</aclResource>
+        <aclResource>Gubee_Integration::UnsuccessfulOrders</aclResource>
         <dataProvider name="gubee_message_order_unsuccessful_listing_data_source" class="Magento\Framework\View\Element\UiComponent\DataProvider\DataProvider">
             <settings>
                 <requestFieldName>id</requestFieldName>


### PR DESCRIPTION
**Lista de alterações.**

**src/etc/acl.xml**
  - Removido recurso órfão Gubee_Integration::index_index
  - Adicionado Gubee_Integration::Message para controlar acesso à tela de mensagens
  - Adicionado Gubee_Integration::UnsuccessfulOrders para controlar acesso à tela de pedidos malsucedidos

  **src/Controller/Adminhtml/Message/Index.php
  src/Controller/Adminhtml/Message/Execute.php
  src/Controller/Adminhtml/Message/Queue.php
  src/Controller/Adminhtml/Message/Detail/Index.php**
  - Adicionado const ADMIN_RESOURCE = 'Gubee_Integration::Message' — sem isso o Magento usava o default Magento_Backend::admin, bloqueando usuários com papel restrito

  **src/Controller/Adminhtml/Message/Order/Unsuccessful/Index.php**
  - Adicionado const ADMIN_RESOURCE = 'Gubee_Integration::UnsuccessfulOrders'

  **src/view/adminhtml/ui_component/gubee_integration_message_listing.xml**
  - O aclResource já era Gubee_Integration::Message — sem alteração, mas agora o recurso existe no ACL e a chamada AJAX do grid para de retornar 403
  
  **src/view/adminhtml/ui_component/gubee_message_order_unsuccessful_index_listing.xml**
  - aclResource trocado de Gubee_Integration::Message para Gubee_Integration::UnsuccessfulOrders
